### PR TITLE
some fixes for python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+bitarray
+unittest2
+python-dabmsc
+crcmod
+python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,14 @@
 from distutils.core import setup
 
 setup(name='dabmot',
-      version='1.0.1',
+      version='1.1',
       description='DAB MOT object assembly and decoding',
       author='Ben Poor',
-      author_email='ben.poor@thisisglobal.com',
-      url='https://github.com/GlobalRadio/python-dabmot',
-      download_url='https://github.com/GlobalRadio/python-dabmot/tarball/1.0.1',
+      author_email='poor@ebu.ch',
+      url='https://github.com/OpenDigitalRadio/python-dabmot',
       packages=['mot'],
       package_dir = {'' : 'src'},
-      keywords = ['dab', 'mot', 'radio']
+      keywords = ['dab', 'mot', 'radio'],
+      test_requires = ['unittest2'],
+      tests = ['test']
      )

--- a/src/mot/__init__.py
+++ b/src/mot/__init__.py
@@ -316,7 +316,7 @@ class ContentName(HeaderParameter):
         bits += int_to_bitarray(self.charset, 4) # (0-3): Character set indicator
         bits += int_to_bitarray(0, 4) # (4-7): RFA
         tmp = bitarray()
-        tmp.fromstring(self.name)
+        tmp.frombytes(self.name.encode())
         bits += tmp
         return bits
     
@@ -341,7 +341,7 @@ class MimeType(HeaderParameter):
         
     def encode_data(self):
         bits = bitarray()
-        bits.fromstring(self.mimetype)
+        bits.frombytes(self.mimetype.encode())
         return bits
     
     @staticmethod
@@ -492,7 +492,7 @@ class DefaultPermitOutdatedVersions(DirectoryParameter):
         
     def encode_data(self):
         bits = bitarray()
-        bits.frombytes("\x01" if self.permit else "\x00")
+        bits.frombytes(b'\x01' if self.permit else b'\x00')
         return bits
 
 class DefaultRelativeExpiration(DirectoryParameter):

--- a/test/mot/test_mot_parameter_encoding.py
+++ b/test/mot/test_mot_parameter_encoding.py
@@ -1,76 +1,88 @@
-import unittest
+import unittest2
 from bitarray import bitarray
+from bitarray.util import ba2hex
 from mot import ContentName, MimeType, AbsoluteExpiration, RelativeExpiration, Compression, Priority, DefaultPermitOutdatedVersions, bitarray_to_hex
 from datetime import datetime, timedelta
 
-class ContentNameTest(unittest.TestCase):
+class ContentNameTest(unittest2.TestCase):
     
     def test_contentname_latin1(self):
         name = ContentName('TEST')
+
         tmp = bitarray()
-        tmp.frombytes('\xCC\x05\x40\x54\x45\x53\x54')
+        tmp.frombytes(b'\xCC\x05\x40\x54\x45\x53\x54')
         assert name.encode() == tmp
         
     def test_contentname_utf(self):
         name = ContentName('TEST', charset=ContentName.ISO_IEC_10646)
+
         tmp = bitarray()
-        tmp.frombytes('\xCC\x05\xF0\x54\x45\x53\x54')
+        tmp.frombytes(b'\xCC\x05\xF0\x54\x45\x53\x54')
         assert name.encode() == tmp
         
-class MimeTypeTest(unittest.TestCase):
+class MimeTypeTest(unittest2.TestCase):
     
     def test_mimetype(self):
         mimetype = MimeType("image/png")
+        
         tmp = bitarray()
-        tmp.frombytes("\xD0\x09\x69\x6D\x61\x67\x65\x2F\x70\x6E\x67")
+        tmp.frombytes(b'\xD0\x09\x69\x6D\x61\x67\x65\x2F\x70\x6E\x67')
         assert mimetype.encode() == tmp
         
-class ExpirationTest(unittest.TestCase):
+class ExpirationTest(unittest2.TestCase):
     
     def test_expire_in_5_minutes(self):
         expiration = RelativeExpiration(timedelta(minutes=5))
+
         tmp = bitarray()
-        tmp.frombytes("\x44\x02")
+        tmp.frombytes(b'\x44\x02')
         assert expiration.encode() == tmp
         
     def test_expire_at_set_date_shortform(self):
         expiration = AbsoluteExpiration(datetime(2010, 8, 11, 12, 34, 0 ,0))
+
         tmp = bitarray()
-        tmp.frombytes("\x84\xB6\x1E\xC3\x22")
+        tmp.frombytes(b'\x84\xB6\x1E\xC3\x22')     
         assert expiration.encode() == tmp
         
     def test_expire_at_set_date_longform(self):
         expiration = AbsoluteExpiration(datetime(2010, 8, 11, 12, 34, 11, 678000))
+
         tmp = bitarray()
-        tmp.frombytes("\xC4\x06\xB6\x1E\xCB\x22\x2E\xA6")
+        tmp.frombytes(b'\xC4\x06\xB6\x1E\xCB\x22\x2E\xA6')
         assert expiration.encode() == tmp
         
-class CompressionType(unittest.TestCase):
+class CompressionType(unittest2.TestCase):
     
     def test_gzip(self):
         param = Compression.GZIP
+
         tmp = bitarray()
-        tmp.frombytes("\x51\x01")
+        tmp.frombytes(b'\x51\x01')
         assert param.encode() == tmp
+
         
-class PriorityTest(unittest.TestCase):
+class PriorityTest(unittest2.TestCase):
     
     def test_priority(self):
         param = Priority(4)
+
         tmp = bitarray()
-        tmp.frombytes("\x4A\x04")
+        tmp.frombytes(b'\x4A\x04')
         assert param.encode() == tmp
         
-class DefaultPermitOutdatedVersionsTest(unittest.TestCase):
+class DefaultPermitOutdatedVersionsTest(unittest2.TestCase):
     
     def test_permitted(self):
         param = DefaultPermitOutdatedVersions(True)
-        assert bitarray_to_hex(param.encode()) == '41 01'
+
+        assert ba2hex(param.encode()) == '4101'
 
     def test_forbidden(self):
         param = DefaultPermitOutdatedVersions(False)
-        assert bitarray_to_hex(param.encode()) == '41 00'
+        
+        assert ba2hex(param.encode()) == '4100'
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest2.main()

--- a/test/mot/test_motobject_encoding.py
+++ b/test/mot/test_motobject_encoding.py
@@ -1,0 +1,29 @@
+import unittest2
+from bitarray import bitarray
+from bitarray.util import ba2hex
+from mot import MotObject, ContentType, MimeType, AbsoluteExpiration
+from datetime import datetime
+
+class MotObjectEncodingTest(unittest2.TestCase):
+    
+    def test_simple_1(self):
+
+        # create MOT object
+        object = MotObject("TestObject", "\x00" * 16, ContentType.IMAGE_JFIF)
+
+    def test_simple_2(self):
+
+        # create MOT object
+        object = MotObject("TestObject", "\x00" * 16, ContentType.IMAGE_JFIF)        
+
+        # add additional parameter - mimetype and absolute expiration
+        object.add_parameter(MimeType("image/jpg"))
+        object.add_parameter(AbsoluteExpiration(datetime(2010, 8, 11, 12, 34, 11, 678000)))
+        
+        tmp = bitarray()
+        tmp.frombytes(b'\x51\x01')
+        assert object.encode() == tmp
+    
+
+if __name__ == "__main__":
+    unittest2.main()


### PR DESCRIPTION
* added `requirements.txt` which was bizarrely missing, noting that we now have  divergence between different projects in the same family that use `distutils` or `setuptools` - need to pick one :)
* restructured the tests, mental note to add more
* not using bitarray_to_hex in favour of new methods in the latest bitarray
* using the latest bitarray
* fixes for python3 upgrade